### PR TITLE
WINDUPRULE-295 JTA: fixed property type issue

### DIFF
--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/when/QueryHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/when/QueryHandler.java
@@ -31,6 +31,7 @@ public class QueryHandler implements ElementHandler<Query>
     public static final String AS = "as";
     public static final String PROPERTY = "property";
     public static final String PROPERTY_NAME = "name";
+    public static final String PROPERTY_TYPE = "type";
 
     @Inject
     private GraphTypeManager graphTypeManager;
@@ -76,7 +77,21 @@ public class QueryHandler implements ElementHandler<Query>
                     continue;
 
                 String value = $(child).text();
-                query.withProperty(propertyName, value);
+                String propertyType = $(child).attr(PROPERTY_TYPE);
+                if (StringUtils.isBlank(propertyType))
+                {
+                    query.withProperty(propertyName, value);
+                } else
+                {
+                    switch (propertyType)
+                    {
+                        case "BOOLEAN":
+                            query.withProperty(propertyName, Boolean.valueOf(value));
+                            break;
+                        case "STRING":
+                            query.withProperty(propertyName, value);
+                    }
+                }
             }
         }
 

--- a/config-xml/schema/windup-jboss-ruleset.xsd
+++ b/config-xml/schema/windup-jboss-ruleset.xsd
@@ -239,6 +239,7 @@
             <xs:element name="property">
                 <xs:complexType mixed="true">
                     <xs:attribute type="xs:string" name="name" use="required" />
+                    <xs:attribute type="property-type" name="type" use="optional" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
@@ -333,6 +334,19 @@
             <xs:enumeration value="REPLACE"/>
             <xs:enumeration value="DELETE_LINE"/>
             <xs:enumeration value="INSERT_LINE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="property-type">
+        <xs:annotation>
+            <xs:documentation><![CDATA[
+            This defines the type of the value of the property.
+            It's optional and default is 'string'.]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="STRING"/>
+            <xs:enumeration value="BOOLEAN"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/model/DataSourceModel.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/model/DataSourceModel.java
@@ -42,7 +42,7 @@ public interface DataSourceModel extends JNDIResourceModel
      * Defines whether it is an XA datasource.
      */
     @Property(IS_XA)
-    public Boolean setXa(Boolean isXa);
+    public void setXa(Boolean isXa);
 
 
     /**


### PR DESCRIPTION
In this fix:

- new optional attribute `type` for `<property>` tag
- this attribute's values are from an enumeration and, right now, only `STRING` and `BOOLEAN` are accepted
- if this attribute is missing, default is `STRING`
- fix for the `setXa` method's signature